### PR TITLE
chore: add .link to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ pnpm-debug.log*
 chrome-profiler-events*.json
 speed-measure-plugin*.json
 
+/.link
 /tmp
 /out-tsc
 /bazel-out


### PR DESCRIPTION
.link is used as a link folder for yarn/npm link when developing within a mounted volume.