### PR TITLE
refactor: remove input device api

### DIFF
--- a/src/core/player.context.ts
+++ b/src/core/player.context.ts
@@ -1,9 +1,9 @@
 import createContext from '@wcom/context';
-import { Device, InputDevice, IS_MOBILE } from '../utils';
+import { Device, IS_MOBILE } from '../utils';
 import { MediaType, PlayerContext, ViewType } from './player.types';
 
-const guessDevice = IS_MOBILE ? Device.Mobile : Device.Desktop;
-const guessInputDevice = IS_MOBILE ? InputDevice.Touch : InputDevice.Mouse;
+const guessDevice =
+  window.innerWidth <= 480 || IS_MOBILE ? Device.Mobile : Device.Desktop;
 
 /**
  * The player context object contains a collection of contexts that map 1:1 with player
@@ -38,10 +38,6 @@ export const playerContext: PlayerContext = {
   device: createContext(guessDevice),
   isMobileDevice: createContext(guessDevice === Device.Mobile),
   isDesktopDevice: createContext(guessDevice === Device.Desktop),
-  inputDevice: createContext(guessInputDevice),
-  isTouchInputDevice: createContext(guessInputDevice === InputDevice.Touch),
-  isMouseInputDevice: createContext(guessInputDevice === InputDevice.Mouse),
-  isKeyboardInputDevice: createContext(false),
   isBuffering: createContext(false),
   isPlaying: createContext(false),
   hasPlaybackStarted: createContext(false),

--- a/src/core/player.events.ts
+++ b/src/core/player.events.ts
@@ -55,8 +55,4 @@ export class DeviceChangeEvent extends buildVdsEvent<PlayerState['device']>(
   'device-change',
 ) {}
 
-export class InputDeviceChangeEvent extends buildVdsEvent<
-  PlayerState['inputDevice']
->('input-device-change') {}
-
 export class ErrorEvent extends buildVdsEvent<unknown>('error') {}

--- a/src/core/player.types.ts
+++ b/src/core/player.types.ts
@@ -1,5 +1,5 @@
 import { Context } from '@wcom/context';
-import { Device, InputDevice } from '../utils';
+import { Device } from '../utils';
 
 export type Source = string;
 
@@ -33,10 +33,6 @@ export type ReadonlyPlayerState = Readonly<
     | 'device'
     | 'isMobileDevice'
     | 'isDesktopDevice'
-    | 'inputDevice'
-    | 'isTouchInputDevice'
-    | 'isMouseInputDevice'
-    | 'isKeyboardInputDevice'
     | 'isBuffering'
     | 'isPlaying'
     | 'hasPlaybackStarted'
@@ -153,39 +149,6 @@ export interface PlayerState {
    * @readonly
    */
   isDesktopDevice: boolean;
-
-  /**
-   * The type of device the player is being interacted with, whether it's mouse/touch/keyboard.
-   * This is determined by listening to mousemove/touchstart/keydown events on `Window` and
-   * toggling this value.
-   *
-   * @readonly
-   */
-  inputDevice: InputDevice;
-
-  /**
-   * Whether the current `inputDevice` is touch (shorthand for
-   * `inputDevice === InputDevice.Touch`).
-   *
-   * @readonly
-   */
-  isTouchInputDevice: boolean;
-
-  /**
-   * Whether the current `inputDevice` is mouse (shorthand for
-   * `inputDevice === InputDevice.Mouse`).
-   *
-   * @readonly
-   */
-  isMouseInputDevice: boolean;
-
-  /**
-   * Whether the current `inputDevice` is keyboard (shorthand for
-   * `inputDevice === InputDevice.Keyboard`).
-   *
-   * @readonly
-   */
-  isKeyboardInputDevice: boolean;
 
   /**
    * Whether playback has temporarily stopped because of a lack of temporary data.

--- a/src/core/tests/FakeConsumer.ts
+++ b/src/core/tests/FakeConsumer.ts
@@ -64,22 +64,6 @@ export class FakeConsumer extends LitElement {
   isDesktopDevice = playerContext.isDesktopDevice.defaultValue;
 
   @internalProperty()
-  @playerContext.inputDevice.consume()
-  inputDevice = playerContext.inputDevice.defaultValue;
-
-  @internalProperty()
-  @playerContext.isTouchInputDevice.consume()
-  isTouchInputDevice = playerContext.isTouchInputDevice.defaultValue;
-
-  @internalProperty()
-  @playerContext.isMouseInputDevice.consume()
-  isMouseInputDevice = playerContext.isMouseInputDevice.defaultValue;
-
-  @internalProperty()
-  @playerContext.isKeyboardInputDevice.consume()
-  isKeyboardInputDevice = playerContext.isKeyboardInputDevice.defaultValue;
-
-  @internalProperty()
   @playerContext.isBuffering.consume()
   isBuffering = playerContext.isBuffering.defaultValue;
 

--- a/src/core/tests/helpers.ts
+++ b/src/core/tests/helpers.ts
@@ -1,6 +1,6 @@
 import { oneEvent } from '@open-wc/testing';
 import { setViewport } from '@web/test-runner-commands';
-import { DeviceChangeEvent, InputDeviceChangeEvent } from '../player.events';
+import { DeviceChangeEvent } from '../player.events';
 import { Player } from '../Player';
 
 export async function switchToMobileDevice(
@@ -21,40 +21,4 @@ export async function switchToDesktopDevice(
     player,
     DeviceChangeEvent.TYPE,
   ) as unknown) as DeviceChangeEvent;
-}
-
-export async function useTouchInputDevice(
-  player: Player,
-): Promise<InputDeviceChangeEvent> {
-  setTimeout(() => {
-    window.dispatchEvent(new TouchEvent('touchstart'));
-  });
-  return (oneEvent(
-    player,
-    InputDeviceChangeEvent.TYPE,
-  ) as unknown) as InputDeviceChangeEvent;
-}
-
-export async function useMouseInputDevice(
-  player: Player,
-): Promise<InputDeviceChangeEvent> {
-  setTimeout(() => {
-    window.dispatchEvent(new MouseEvent('mousemove'));
-  });
-  return (oneEvent(
-    player,
-    InputDeviceChangeEvent.TYPE,
-  ) as unknown) as InputDeviceChangeEvent;
-}
-
-export async function useKeyboardInputDevice(
-  player: Player,
-): Promise<InputDeviceChangeEvent> {
-  setTimeout(() => {
-    window.dispatchEvent(new KeyboardEvent('keydown'));
-  });
-  return (oneEvent(
-    player,
-    InputDeviceChangeEvent.TYPE,
-  ) as unknown) as InputDeviceChangeEvent;
 }

--- a/src/core/tests/player-misc.test.ts
+++ b/src/core/tests/player-misc.test.ts
@@ -1,14 +1,8 @@
 import '../vds-player';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
-import { Device, InputDevice } from '../../utils/dom';
+import { Device } from '../../utils/dom';
 import { Player } from '../Player';
-import {
-  switchToDesktopDevice,
-  switchToMobileDevice,
-  useKeyboardInputDevice,
-  useMouseInputDevice,
-  useTouchInputDevice,
-} from './helpers';
+import { switchToDesktopDevice, switchToMobileDevice } from './helpers';
 import { PlayerContextProvider } from '../player.types';
 
 describe('render', () => {
@@ -94,61 +88,5 @@ describe('device change', () => {
     expect(provider.isDesktopDeviceCtx).to.be.true;
     expect(player).to.have.attribute('desktop', 'true');
     expect(player).to.not.have.attribute('mobile', 'true');
-  });
-});
-
-describe('input device change', () => {
-  it('should update when screen is touched', async () => {
-    const player = await fixture<Player>(html`<vds-player></vds-player>`);
-    const provider = (player as unknown) as PlayerContextProvider;
-    const { detail } = await useTouchInputDevice(player);
-    const expectedInputDevice = InputDevice.Touch;
-    expect(detail).to.be.equal(expectedInputDevice);
-    expect(player.inputDevice).to.equal(expectedInputDevice);
-    expect(player.isTouchInputDevice).to.be.true;
-    expect(player.isMouseInputDevice).to.be.false;
-    expect(player.isKeyboardInputDevice).to.be.false;
-    expect(provider.isTouchInputDeviceCtx).to.be.true;
-    expect(provider.isMouseInputDeviceCtx).to.be.false;
-    expect(provider.isKeyboardInputDeviceCtx).to.be.false;
-    expect(player).to.have.attribute('touch', 'true');
-    expect(player).to.not.have.attribute('mouse', 'true');
-    expect(player).to.not.have.attribute('keyboard', 'true');
-  });
-
-  it('should update mouse is moved', async () => {
-    const player = await fixture<Player>(html`<vds-player></vds-player>`);
-    const provider = (player as unknown) as PlayerContextProvider;
-    const { detail } = await useMouseInputDevice(player);
-    const expectedInputDevice = InputDevice.Mouse;
-    expect(detail).to.be.equal(expectedInputDevice);
-    expect(player.inputDevice).to.equal(expectedInputDevice);
-    expect(player.isTouchInputDevice).to.be.false;
-    expect(player.isMouseInputDevice).to.be.true;
-    expect(player.isKeyboardInputDevice).to.be.false;
-    expect(provider.isTouchInputDeviceCtx).to.be.false;
-    expect(provider.isMouseInputDeviceCtx).to.be.true;
-    expect(provider.isKeyboardInputDeviceCtx).to.be.false;
-    expect(player).to.have.attribute('mouse', 'true');
-    expect(player).to.not.have.attribute('touch', 'true');
-    expect(player).to.not.have.attribute('keyboard', 'true');
-  });
-
-  it('should update when keyboard is used', async () => {
-    const player = await fixture<Player>(html`<vds-player></vds-player>`);
-    const provider = (player as unknown) as PlayerContextProvider;
-    const { detail } = await useKeyboardInputDevice(player);
-    const expectedInputDevice = InputDevice.Keyboard;
-    expect(detail).to.be.equal(expectedInputDevice);
-    expect(player.inputDevice).to.equal(expectedInputDevice);
-    expect(player.isTouchInputDevice).to.be.false;
-    expect(player.isMouseInputDevice).to.be.false;
-    expect(player.isKeyboardInputDevice).to.be.true;
-    expect(provider.isTouchInputDeviceCtx).to.be.false;
-    expect(provider.isMouseInputDeviceCtx).to.be.false;
-    expect(provider.isKeyboardInputDeviceCtx).to.be.true;
-    expect(player).to.have.attribute('keyboard', 'true');
-    expect(player).to.not.have.attribute('touch', 'true');
-    expect(player).to.not.have.attribute('mouse', 'true');
   });
 });

--- a/src/core/tests/player-props.test.ts
+++ b/src/core/tests/player-props.test.ts
@@ -1,6 +1,6 @@
 import '../vds-player';
 import { expect, fixture, html } from '@open-wc/testing';
-import { Device, InputDevice } from '../../utils';
+import { Device } from '../../utils';
 import { Player } from '../Player';
 import { playerContext } from '../player.context';
 import {
@@ -34,10 +34,6 @@ describe('props', async () => {
       device: Device.Mobile,
       isMobileDevice: false,
       isDesktopDevice: false,
-      inputDevice: InputDevice.Mouse,
-      isTouchInputDevice: false,
-      isMouseInputDevice: false,
-      isKeyboardInputDevice: false,
       isBuffering: false,
       isPlaying: false,
       hasPlaybackStarted: false,

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -50,60 +50,6 @@ export const isColliding = (
   );
 };
 
-export enum InputDevice {
-  Touch = 'touch',
-  Mouse = 'mouse',
-  Keyboard = 'keyboard',
-}
-
-/**
- * Listens for input device changes (mouse/touch) and invokes a callback with the current
- * input device.
- *
- * @param callback - Called when the input device is changed.
- */
-export const onInputDeviceChange = (
-  callback: (inputDevice: InputDevice) => void,
-  isClient = IS_CLIENT,
-  shouldIgnoreEmulatedTouchEvents = true,
-): Unsubscribe => {
-  if (!isClient) return noop;
-
-  let lastTouchTime = 0;
-
-  const offTouchListener = listenTo(
-    window,
-    'touchstart',
-    () => {
-      lastTouchTime = new Date().getTime();
-      callback(InputDevice.Touch);
-    },
-    true,
-  );
-
-  const offMouseListener = listenTo(
-    window,
-    'mousemove',
-    () => {
-      // Filter emulated events coming from touch events.
-      const isEmulatedEvent = new Date().getTime() - lastTouchTime < 500;
-      if (shouldIgnoreEmulatedTouchEvents && isEmulatedEvent) return;
-      callback(InputDevice.Mouse);
-    },
-    true,
-  );
-
-  const offKeyboardListener = listenTo(window, 'keydown', () => {
-    callback(InputDevice.Keyboard);
-  });
-
-  return () => {
-    offTouchListener();
-    offMouseListener();
-    offKeyboardListener();
-  };
-};
-
 export enum Device {
   Mobile = 'mobile',
   Desktop = 'desktop',


### PR DESCRIPTION
CSS Media Queries combined with Media Features solves the issue of styling independently between mouse/touch. If this API is required we can bring it back in a future release.

BREAKING CHANGE:

The following player properties/context/events were removed:

- `inputDevice`
- `isTouchInputDevice`
- `isMouseInputDevice`
- `isKeyboardInputDevice`
- `vds-input-device-change`

The following were removed from `utils/dom`:

- `InputDevice`
- `onInputDeviceChange`