### PR TITLE
reverse inverted slot names for pause and play

### DIFF
--- a/src/ui/controls/playback-toggle/PlaybackToggle.ts
+++ b/src/ui/controls/playback-toggle/PlaybackToggle.ts
@@ -109,11 +109,11 @@ export class PlaybackToggle extends FocusMixin(Toggle) {
   }
 
   protected getOnSlotName(): string {
-    return 'pause';
+    return 'play';
   }
 
   protected getOffSlotName(): string {
-    return 'play';
+    return 'pause';
   }
 
   protected handleTogglingPlayback(originalEvent: Event): void {

--- a/src/ui/controls/playback-toggle/tests/playback-toggle.test.ts
+++ b/src/ui/controls/playback-toggle/tests/playback-toggle.test.ts
@@ -37,22 +37,22 @@ describe(PLAYBACK_TOGGLE_TAG_NAME, () => {
     expect(pauseSlot).to.have.class('pause');
   });
 
-  it('should set play slot to hidden when paused is true', async () => {
+  it('should set pause slot to hidden when paused is true', async () => {
     const [, toggle] = await buildFixture();
     const playSlot = getSlottedChildren(toggle, 'play')[0];
     const pauseSlot = getSlottedChildren(toggle, 'pause')[0];
-    expect(playSlot).to.have.attribute('hidden', '');
-    expect(pauseSlot).to.not.have.attribute('hidden');
+    expect(pauseSlot).to.have.attribute('hidden', '');
+    expect(playSlot).to.not.have.attribute('hidden');
   });
 
-  it('should set pause slot to hidden when paused is true', async () => {
+  it('should set play slot to hidden when paused is true', async () => {
     const [, toggle] = await buildFixture();
     toggle.on = false;
     await elementUpdated(toggle);
     const playSlot = getSlottedChildren(toggle, 'play')[0];
     const pauseSlot = getSlottedChildren(toggle, 'pause')[0];
-    expect(pauseSlot).to.have.attribute('hidden', '');
-    expect(playSlot).to.not.have.attribute('hidden');
+    expect(playSlot).to.have.attribute('hidden', '');
+    expect(pauseSlot).to.not.have.attribute('hidden');
   });
 
   it('should toggle pressed state correctly', async () => {


### PR DESCRIPTION
It appears you made a simple (and very common) oversight in the naming of the slots.

This is one reason I personally prefer active properties like `playing`. It feels more natural to me when `true` reflects the active state. Paused feels "off" > 0 > false. Playing feels "on" > 1 > true. 🤷‍♂️