### PR TITLE
Add "maybe" to `canPlayType` validation

### DIFF
--- a/src/providers/file/MediaFileProvider.ts
+++ b/src/providers/file/MediaFileProvider.ts
@@ -433,7 +433,10 @@ export class MediaFileProvider<
       return false;
     }
 
-    return this.mediaEl.canPlayType(type) === CanPlayTypeResult.Probably;
+    return (
+      this.mediaEl.canPlayType(type) === CanPlayTypeResult.Probably ||
+      this.mediaEl.canPlayType(type) === CanPlayTypeResult.Maybe
+    );
   }
 
   async play(): Promise<void> {


### PR DESCRIPTION
This is required to pass on iOS Safari. However, a cleaner approach would be to pass through the actual value from this function. Otherwise, it may be obscuring a necessary detail at too low of a level. This fix adds convenience at the cost of clarity.