### PR TITLE
only use delay when displaying indicator

### DIFF
--- a/src/ui/buffering-indicator/BufferingIndicator.ts
+++ b/src/ui/buffering-indicator/BufferingIndicator.ts
@@ -97,7 +97,9 @@ export class BufferingIndicator extends LitElement {
   }
 
   protected handleTogglingHiddenAttr(): void {
-    if (this.delay === 0) {
+    const shouldBeHidden = this.isIndicatorHidden();
+
+    if (shouldBeHidden || this.delay === 0) {
       this.toggleHiddenAttr();
       return;
     }


### PR DESCRIPTION
The indicator was lingering once playback resumed. It should be dismissed immediately.